### PR TITLE
Add header item

### DIFF
--- a/src/leaflet-bootstrap-dropdowns.js
+++ b/src/leaflet-bootstrap-dropdowns.js
@@ -45,6 +45,7 @@
          * @property {string} options.ariaLabel - ARIA label for the button.
          * @property {Array<Object>} options.menuItems - Array of menu items.
          * @property {boolean} options.menuItems[].separator - If true, adds a separator.
+         * @property {boolean} options.menuItems[].header - If true, treat this item as a header.
          * @property {string} options.menuItems[].html - HTML content of the menu item.
          * @property {string} options.menuItems[].title - Title attribute of the menu item.
          * @property {string} options.menuItems[].ariaLabel - ARIA label for the menu item.
@@ -109,22 +110,24 @@
                     continue;
                 }
 
-                const anchor = L.DomUtil.create("a", "dropdown-item", li);
+                const anchor = (item.header) ? L.DomUtil.create("div", "dropdown-header", li) : L.DomUtil.create("a", "dropdown-item", li);
                 if (item.html) anchor.innerHTML = item.html;
                 if (item.title) anchor.title = item.title;
                 if (item.title || item.ariaLabel) anchor.setAttribute("aria-label", item.ariaLabel ? item.ariaLabel : item.title);
 
-                if (item.current) {
-                    L.DomUtil.addClass(anchor, "current");
-                    anchor.href = "#";
-                    L.DomEvent.on(anchor, "click", L.DomEvent.preventDefault);
-                } else {
-                    if (item.href && item.href !== "#") {
-                        anchor.href = item.href;
-                        if (item.target) anchor.target = item.target;
-                        if (item.rel) anchor.rel = item.rel;
-                    } else if (item.afterClick) {
-                        L.DomEvent.on(anchor, "click", item.afterClick);
+                if(!item.header) {
+                    if (item.current) {
+                        L.DomUtil.addClass(anchor, "current");
+                        anchor.href = "#";
+                        L.DomEvent.on(anchor, "click", L.DomEvent.preventDefault);
+                    } else {
+                        if (item.href && item.href !== "#") {
+                            anchor.href = item.href;
+                            if (item.target) anchor.target = item.target;
+                            if (item.rel) anchor.rel = item.rel;
+                        } else if (item.afterClick) {
+                            L.DomEvent.on(anchor, "click", item.afterClick);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This adds the ability to specify a menu header, which can display arbitrary html.

Note that you'll want to add some CSS if you put anything more complex than a few words. My menu header has a title and a short paragraph of instructions and this is what I used.

```css
.leaflet-bootstrap-dropdowns .dropdown-header {
    text-wrap: auto;
}

.leaflet-bootstrap-dropdowns .dropdown-header h5 {
    color: rgba(var(--primary-rgb), 1);
}

.leaflet-bootstrap-dropdowns .dropdown-header p {
    margin: 0;
    padding: 0;
}
```
<img width="389" alt="Screenshot 2025-07-09 at 1 21 44 PM" src="https://github.com/user-attachments/assets/2dcfe02b-dae7-4a11-bb59-3259b23c92e2" />
